### PR TITLE
fix(passkey): normalize ECDSA high-S signatures to prevent login failures

### DIFF
--- a/assertion_test.go
+++ b/assertion_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestParseAssertion(t *testing.T) {
-	t.Parallel()
-
 	validAuthData := base64.RawURLEncoding.EncodeToString([]byte("auth-data"))
 	validClientData := base64.RawURLEncoding.EncodeToString([]byte("client-data"))
 	validSignature := base64.RawURLEncoding.EncodeToString([]byte("signature"))

--- a/challenge_test.go
+++ b/challenge_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestCheckChallenge(t *testing.T) {
-	t.Parallel()
-
 	type args struct {
 		expectedB64 string
 		receivedB64 string

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -1,0 +1,13 @@
+package passkey
+
+import "math/big"
+
+// ToLowS normalizes an ECDSA S value to a canonical low-S form as recommended by FIDO/WebAuthn specifications.
+// If S is greater than half the curve order, it is replaced with N - S.
+func ToLowS(s *big.Int, curveN *big.Int) *big.Int {
+	halfOrder := new(big.Int).Rsh(curveN, 1)
+	if s.Cmp(halfOrder) == 1 {
+		return new(big.Int).Sub(curveN, s)
+	}
+	return s
+}

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,0 +1,58 @@
+package passkey_test
+
+import (
+	"crypto/elliptic"
+	"math/big"
+	"testing"
+
+	"github.com/aethiopicuschan/passkey-go"
+)
+
+// TestToLowS verifies that toLowS correctly normalizes S to a low-S form.
+func TestToLowS(t *testing.T) {
+	curve := elliptic.P256()
+	N := curve.Params().N
+	halfN := new(big.Int).Rsh(N, 1)
+
+	tests := []struct {
+		name     string
+		inputS   *big.Int
+		expected *big.Int
+	}{
+		{
+			name:     "S below halfN stays the same",
+			inputS:   big.NewInt(1),
+			expected: big.NewInt(1),
+		},
+		{
+			name:     "S equal to halfN stays the same",
+			inputS:   new(big.Int).Set(halfN),
+			expected: new(big.Int).Set(halfN),
+		},
+		{
+			name:     "S above halfN is normalized",
+			inputS:   new(big.Int).Add(halfN, big.NewInt(1)),
+			expected: new(big.Int).Sub(N, new(big.Int).Add(halfN, big.NewInt(1))),
+		},
+		{
+			name:     "S equal to N - 1 is normalized",
+			inputS:   new(big.Int).Sub(N, big.NewInt(1)),
+			expected: big.NewInt(1),
+		},
+		{
+			name:     "S equal to N is normalized to 0",
+			inputS:   new(big.Int).Set(N),
+			expected: big.NewInt(0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := passkey.ToLowS(tt.inputS, N)
+			if got.Cmp(tt.expected) != 0 {
+				t.Errorf("ToLowS(%v) = %v; want %v", tt.inputS, got, tt.expected)
+			}
+		})
+	}
+}

--- a/publickey_test.go
+++ b/publickey_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestMarshalUnmarshalPublicKey(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		setupKey   func() ([]byte, error) // prepares the input bytes

--- a/verify_test.go
+++ b/verify_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestVerifyAssertionSignature(t *testing.T) {
-	t.Parallel()
-
 	// Generate ECDSA key pair
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	assert.NoError(t, err)


### PR DESCRIPTION
close #5 